### PR TITLE
Update display first 5 rows of combined data

### DIFF
--- a/INTRUSION_DETECTION-FINAL.ipynb
+++ b/INTRUSION_DETECTION-FINAL.ipynb
@@ -487,7 +487,7 @@
     "\n",
     "combined_data.columns = labels\n",
     "combined_data = combined_data.drop('difficulty_level', axis= 1)\n",
-    "combined_data.head(3)"
+    "combined_data.head(5)"
    ]
   },
   {


### PR DESCRIPTION
#Updated the display statement to print the first 5 lines instead of 3 for Combined data.

There seems to be an outlier in the 5th row of the combined dataset. 
- For the outlier's visibility, the .head() function has been changed.